### PR TITLE
npm install is added in Docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get install --no-install-recommends -y maven openjdk-11-jdk nodejs
 
 WORKDIR /opt/moderated-meetings
 COPY . .
+RUN npm install
 RUN mvn package
 RUN npm run build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,8 @@ RUN apt-get install --no-install-recommends -y maven openjdk-11-jdk nodejs
 
 WORKDIR /opt/moderated-meetings
 COPY . .
-RUN npm install
 RUN mvn package
-RUN npm run build
+RUN npm install && npm run build
 
 FROM openjdk:11
 


### PR DESCRIPTION
To avoid npm error "sh 1: webpack not found" while building the docker image added "RUN npm install" command in Dockerfile