### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/src/main/js/functions/urlUtils.ts
+++ b/src/main/js/functions/urlUtils.ts
@@ -6,7 +6,7 @@
  */
 export function parseQueryParams(query: string = ''): Record<string, unknown> {
     const parsedQueryParams = {};
-    const params = query.substr(query.startsWith('?') ? 1 : 0).split('&');
+    const params = query.slice(query.startsWith('?') ? 1 : 0).split('&');
 
     for (const param of params) {
         const [ key, value ] = param.split('=');


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.