### PR TITLE
feat: show jwt link directly for moderators and copy it

### DIFF
--- a/src/main/js/screens/Join.tsx
+++ b/src/main/js/screens/Join.tsx
@@ -65,7 +65,7 @@ class Join extends Screen<Props, State> {
      * @inheritdoc
      */
     public renderContent(): ReactNode {
-        const { joinUrl } = this.state;
+        const { joinUrl, moderatorUrl } = this.state;
 
         if (!joinUrl) {
             return null;
@@ -97,14 +97,14 @@ class Join extends Screen<Props, State> {
                 <hr />
                 <div className = 'content-box-section'>
                     <label htmlFor = 'moderatorUrl'>
-                        Share this page with other moderators
+                        Share this link with other moderators
                     </label>
                     <div className = 'copy-field-wrapper'>
-                        <input
+                        <textarea
                             id = 'moderatorUrl'
                             readOnly = { true }
-                            type = 'text'
-                            value = { document.location.href } />
+                            rows = { 4 }
+                            value = { moderatorUrl } />
                         <button
                             className = 'text'
                             onClick = { this.copyUrl('moderatorUrl') }>

--- a/src/main/scss/ui-kit.scss
+++ b/src/main/scss/ui-kit.scss
@@ -72,7 +72,8 @@ hr {
     width: 100%;
 }
 
-input {
+input,
+textarea {
     flex: 1;
     font-family: 'Open Sans', sans-serif;
 }
@@ -86,7 +87,7 @@ main {
     align-self: center;
     flex: 1;
     flex-direction: column;
-    max-width: 480px;
+    max-width: 720px;
 }
 
 p {
@@ -105,7 +106,8 @@ p {
     margin: 8px 0;
     padding: 8px;
 
-    input {
+    input,
+    textarea {
         background: none;
         border: none;
         color: $text;
@@ -113,6 +115,11 @@ p {
         font-weight: 300;
         pointer-events: none;
         text-overflow: ellipsis;
+    }
+
+    textarea {
+        resize: none;
+        overflow: hidden;
     }
 }
 


### PR DESCRIPTION
Allows joining as moderator via the mobile and electron apps
