### PR TITLE
fix: Fixes starting locally.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "webpack",
     "lint": "eslint --ext .ts,.tsx ./src/main/js",
-    "start": "npm run build && source .env && mvn spring-boot:run",
+    "start": "npm run build && eval $(cat .env) mvn spring-boot:run",
     "test": "mvn test",
     "watch": "webpack --watch"
   },


### PR DESCRIPTION
The .env were not exported and used for the maven command/the java part. It was failing with NumberFormatException: null.